### PR TITLE
Use Python 2.x

### DIFF
--- a/src/chrome/content/dockyunread.js
+++ b/src/chrome/content/dockyunread.js
@@ -47,7 +47,7 @@ var dockyunread = {
 		var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);		
 		file.initWithPath("/usr/bin/env");
 		
-		var args = ["python", path, x];
+		var args = ["python2", path, x];
 		var process = Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
 		process.init(file);
 		


### PR DESCRIPTION
For me on ArchLinux 'python' is an alias for Python 3.x, but this script need Python 2.x, so I made use of the python2 alias, which I assume has been in most distributions for a long time now.
