### PR TITLE
Fix: Badge counts one less message, than there actually is

### DIFF
--- a/src/chrome/content/dockyunread.js
+++ b/src/chrome/content/dockyunread.js
@@ -118,7 +118,9 @@ var dockyunread = {
 		while(subFoldersEnumerator.hasMoreElements()) {
 			var folder = subFoldersEnumerator.getNext().QueryInterface(Components.interfaces.nsIMsgFolder);
 			dump("Get Number of unread messages with travese deep = " +  this.traverseDeep + "\n");
-			totalCount += folder.getNumUnread(false);
+			var count = folder.getNumUnread(false);
+			if (count > 0)
+				totalCount += count;
 		}
 		
 		dump("Found total " + totalCount + "in all subFolders\n");


### PR DESCRIPTION
This solution seems to be a hack rather than fix. When using "count messages in subfolders" option, "Local Folders" counts "-1" apart from its subfolders.
